### PR TITLE
fix-login-allowAnonimous

### DIFF
--- a/Src/NDDTrainig.Test/NDDTrainig.Test.csproj
+++ b/Src/NDDTrainig.Test/NDDTrainig.Test.csproj
@@ -11,7 +11,6 @@
    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.3.0" />
    <PackageReference Include="FluentValidation.Validators.UnitTestExtension" Version="1.11.0.2" />
    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0" />

--- a/Src/NDDTraining.API/Controllers/AuthenticationsController.cs
+++ b/Src/NDDTraining.API/Controllers/AuthenticationsController.cs
@@ -8,7 +8,7 @@ namespace NDDTraining.API.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    [Authorize]
+    [AllowAnonymous]
     public class AuthenticationsController : Controller
     {
         private readonly IUserService _userService;


### PR DESCRIPTION
## Corrigido ##

Melhorar a rota de login tem que permitir acesso anônimo sem o [Authorize]

**Plus:  Removido PackageReference duplicado em NDDTraining.Test 